### PR TITLE
When an association is added/removed, we should break the cache for t…

### DIFF
--- a/lib/autobots/helpers/caching.rb
+++ b/lib/autobots/helpers/caching.rb
@@ -46,7 +46,7 @@ module Autobots
 
       def serializer_cache_key
         return @serializer_cache_key if defined?(@serializer_cache_key)
-        @serializer_cache_key = [serializer.name, Digest::SHA256.hexdigest(serializer._attributes.keys.to_s)[0..12]]
+        @serializer_cache_key = [serializer.name, Digest::SHA256.hexdigest(serializer._attributes.keys.to_s + serializer._associations.keys.to_s)[0..12]]
       end
 
       def cache_key(object, _)

--- a/test/caching_test.rb
+++ b/test/caching_test.rb
@@ -45,4 +45,17 @@ class CachingTest < ActiveSupport::TestCase
     assert_equal expected_data, data
   end
 
+  def test_cache_key_contains_associations
+    cache = ActiveSupport::Cache::MemoryStore.new
+    projects = Project.all
+    assembler = CacheBustOnAssociationChangeAssembler.new(projects, cache: cache)
+    cache_key_with_associations = assembler.send(:serializer_cache_key)
+
+    assembler.serializer._associations = {}
+    assembler.remove_instance_variable(:@serializer_cache_key)
+    cache_key_without_associations = assembler.send(:serializer_cache_key)
+
+    assert_not_equal cache_key_with_associations, cache_key_without_associations
+  end
+
 end

--- a/test/caching_test.rb
+++ b/test/caching_test.rb
@@ -48,12 +48,16 @@ class CachingTest < ActiveSupport::TestCase
   def test_cache_key_contains_associations
     cache = ActiveSupport::Cache::MemoryStore.new
     projects = Project.all
-    assembler = CacheBustOnAssociationChangeAssembler.new(projects, cache: cache)
+    assembler = ProjectPreloadIncludedAssembler.new(projects, cache: cache)
     cache_key_with_associations = assembler.send(:serializer_cache_key)
 
+    saved_associations = assembler.serializer._associations
     assembler.serializer._associations = {}
     assembler.remove_instance_variable(:@serializer_cache_key)
+
     cache_key_without_associations = assembler.send(:serializer_cache_key)
+
+    assembler.serializer._associations = saved_associations
 
     assert_not_equal cache_key_with_associations, cache_key_without_associations
   end

--- a/test/test_models.rb
+++ b/test/test_models.rb
@@ -15,11 +15,6 @@ class CommentSerializer < ActiveModel::Serializer
   attributes :id, :title, :body
 end
 
-class CacheBustOnAssociationChangeSerializer < ActiveModel::Serializer
-  attributes :id, :name
-  has_many :issues
-end
-
 class ProjectAssembler < Autobots::Assembler
   self.serializer = ProjectSerializer
 end
@@ -47,13 +42,6 @@ class ProjectIdAssembler < Autobots::Assembler
   self.serializer = ProjectSerializer
   def assemble(identifiers)
     Project.where(id: identifiers).to_a
-  end
-end
-
-class CacheBustOnAssociationChangeAssembler < Autobots::ActiveRecordAssembler
-  self.serializer = CacheBustOnAssociationChangeSerializer
-  def preloads
-    {issues: :comments}
   end
 end
 

--- a/test/test_models.rb
+++ b/test/test_models.rb
@@ -15,6 +15,11 @@ class CommentSerializer < ActiveModel::Serializer
   attributes :id, :title, :body
 end
 
+class CacheBustOnAssociationChangeSerializer < ActiveModel::Serializer
+  attributes :id, :name
+  has_many :issues
+end
+
 class ProjectAssembler < Autobots::Assembler
   self.serializer = ProjectSerializer
 end
@@ -42,6 +47,13 @@ class ProjectIdAssembler < Autobots::Assembler
   self.serializer = ProjectSerializer
   def assemble(identifiers)
     Project.where(id: identifiers).to_a
+  end
+end
+
+class CacheBustOnAssociationChangeAssembler < Autobots::ActiveRecordAssembler
+  self.serializer = CacheBustOnAssociationChangeSerializer
+  def preloads
+    {issues: :comments}
   end
 end
 


### PR DESCRIPTION
…he assembled object, instead of just doing that for attribute changes.
